### PR TITLE
Refactor: Replace unwrap with proper error handling in handlers

### DIFF
--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -102,7 +102,9 @@ pub async fn login(
 
         let mut headers = HeaderMap::new();
 
-        headers.append(header::SET_COOKIE, cookie.to_string().parse().unwrap());
+        let cookie_val = cookie.to_string().parse()
+            .map_err(|e| HttpError::server_error(format!("Failed to parse cookie: {}", e)))?;
+        headers.append(header::SET_COOKIE, cookie_val);
 
         let mut response = response.into_response();
         response.headers_mut().extend(headers);
@@ -115,20 +117,20 @@ pub async fn login(
     }
 }
 
-pub async fn logout(State(app_state): State<Arc<AppState>>) -> impl IntoResponse {
+pub async fn logout(State(app_state): State<Arc<AppState>>) -> Result<impl IntoResponse, HttpError> {
     let cookie = axum::http::HeaderValue::from_str(
         "access_token=; Path=/; HttpOnly; Max-Age=0; SameSite=None; Secure",
     )
-    .unwrap();
+    .map_err(|e| HttpError::server_error(e.to_string()))?;
 
     let mut headers = HeaderMap::new();
     headers.insert(header::SET_COOKIE, cookie);
 
-    (
+    Ok((
         headers,
         Json(Response {
             status: "success",
             message: "Logged out successfully".to_string(),
         }),
-    )
+    ))
 }

--- a/src/handlers/chat.rs
+++ b/src/handlers/chat.rs
@@ -41,11 +41,19 @@ pub async fn read_loop(
             created_at: Utc::now(),
         };
 
-        let message = Message::Text(serde_json::to_string(&out).unwrap().into());
+        let out_str = match serde_json::to_string(&out) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("Failed to serialize message: {}", e);
+                continue;
+            }
+        };
+
+        let message = Message::Text(out_str.clone().into());
 
         let _ = users_chat::send_to_user(
             other_user,
-            Message::Text(serde_json::to_string(&out).unwrap().into()),
+            Message::Text(out_str.into()),
             &state,
         )
         .await;


### PR DESCRIPTION
Closes #10

Replaced multiple instances of `.unwrap()` in authentication and chat handlers to prevent potential server panics.

- Modified `logout` signature to return a `Result`
- Implemented error logging for WebSocket serialization failures

This change ensures safer error handling and prevents unexpected server crashes due to panics.